### PR TITLE
match react-admin's material-ui dependencies, otherwise it install 2 …

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@material-ui/core": "^3.3.2",
+    "@material-ui/core": "^1.4.0",
     "codemirror": "^5.40.0",
     "lodash.get": "^4.4.2",
     "lodash.map": "^4.6.0",


### PR DESCRIPTION
…versions of material-ui and creates conflicting withStyle HOC. See https://github.com/marmelab/react-admin/issues/1782